### PR TITLE
fix aqueduct stopping when process is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.10.4
+- fixed unfinished stopping on child process death
+
 # 1.10.3
 - fixed reraise asyncio.CancelledError if the cause of exception is external actor
 

--- a/aqueduct/integrations/aiohttp.py
+++ b/aqueduct/integrations/aiohttp.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import signal
 import sys
 
 from aqueduct.flow import Flow
@@ -18,7 +20,10 @@ async def observe_flows(app: web.Application, check_interval: float = 1.):
         for flow_name, flow in flows.items():
             if not flow.is_running:
                 log.info(f'Flow {flow_name} is not running, application will be stopped')
-                sys.exit(1)
+                pid = os.getpid()
+                # kill process with SIGTERM to ensure, that stopping would not be delayed by other code (like aiohttp)
+                os.kill(pid, signal.SIGTERM)
+
         await asyncio.sleep(check_interval)
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ packages = ['aqueduct']
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.10.3',
+    version='1.10.4',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',

--- a/tests/unit/integrations/test_aiohttp.py
+++ b/tests/unit/integrations/test_aiohttp.py
@@ -1,10 +1,12 @@
 import asyncio
+import multiprocessing
+import time
 from unittest.mock import AsyncMock
 
 import aiohttp.web
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import setup_test_loop, TestClient
+from aiohttp.test_utils import TestClient
 
 from aqueduct import Flow
 from aqueduct.integrations.aiohttp import (
@@ -25,6 +27,17 @@ async def init_app(app: web.Application):
     app.on_cleanup.insert(0, AsyncMock())
 
     return app
+
+
+def wait_process_stop(proc: multiprocessing.Process, timeout: int):
+    stoped = False
+    for i in range(10):
+        time.sleep(1)
+        stoped = not proc.is_alive()
+        if stoped:
+            break
+
+    assert stoped is True
 
 
 @pytest.fixture
@@ -60,23 +73,27 @@ class TestAppIntegrator:
         assert app.on_shutdown[0].called is True
         assert app.on_cleanup[0].called is True
 
-    def test_app_exists_on_flow_stop(self, loop):
-        async def error_exit(_):
-            async def stop_task():
-                await asyncio.sleep(1)
-                await terminate_worker(app[FLOW_NAME])
+    def test_app_exits_on_flow_stop(self):
+        def sub_proc():
+            async def error_exit(_):
+                async def stop_task():
+                    await asyncio.sleep(1)
+                    await terminate_worker(app[FLOW_NAME])
 
-            asyncio.create_task(stop_task())
+                asyncio.create_task(stop_task())
 
-        app = web.Application()
-        app.on_startup.append(error_exit)
+            app = web.Application()
+            app.on_startup.append(error_exit)
 
-        with pytest.raises(SystemExit) as info:
             aiohttp.web.run_app(init_app(app))
 
-        assert info.value.code == 1
-        assert app.on_shutdown[0].called is True
-        assert app.on_cleanup[0].called is True
+            return True
+
+        p = multiprocessing.Process(target=sub_proc)
+        p.start()
+        time.sleep(1)
+        wait_process_stop(p, 10)
+
 
     async def test_unittest_teardown(self, app_with_flow: web.Application, app_client):
         """Flow monitoring should not brake unit tests.


### PR DESCRIPTION
There is some situations when applications hangs on stopping. To ensure that we will eventually stop - use os.kill instead of SystemExit exceptions.