### PR TITLE
Allowed different multiprocessing start method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.10.9
+- Add ability to set different subprocess start methods and on_start_timeout for heavyweight models
+
 # 1.10.8
 - Add metric for task size in bytes
 

--- a/aqueduct/exceptions.py
+++ b/aqueduct/exceptions.py
@@ -6,6 +6,10 @@ class FlowError(AqueductError):
     """Flow can raise this if something was wrong."""
 
 
+class MPStartMethodValueError(FlowError, ValueError):
+    """Flow will raise this if flow's method to start subprocess differs from the main method"""
+
+
 class NotRunningError(FlowError):
     """Flow can raise this if it's not already running."""
 

--- a/aqueduct/flow.py
+++ b/aqueduct/flow.py
@@ -52,6 +52,7 @@ class FlowStep:
             nprocs: int = 1,
             batch_size: int = 1,
             batch_timeout: float = 0,
+            on_start_timeout: float = 0,
     ):
         _check_env()
         self.handler = handler
@@ -59,6 +60,7 @@ class FlowStep:
         self.nprocs = nprocs
         self.batch_size = batch_size
         self.batch_timeout = batch_timeout
+        self.on_start_timeout = on_start_timeout
 
 
 class FlowState(Enum):
@@ -238,6 +240,7 @@ class Flow:
                 worker_curr.loop,
                 nprocs=step.nprocs, join=False, daemon=True, start_method=self._mp_start_method,
                 args=(start_barrier,),
+                on_start_timeout=step.on_start_timeout,
             )
             log.info(f'Created step {step.handler}, '
                      f'queue_in: {self._queues[-2]}, queue_out:{self._queues[-1]}')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ packages = ['aqueduct']
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.10.8',
+    version='1.10.9',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -306,7 +306,7 @@ class TestFlow:
         """
         await asyncio.wait_for(
             process_tasks(flow_with_dynamic_batch_handler, tasks_batch),
-            timeout=CatDetector.BATCH_PROCESS_TIME + CatDetector.IMAGE_PROCESS_TIME,
+            timeout=CatDetector.BATCH_PROCESS_TIME + CatDetector.IMAGE_PROCESS_TIME + CatDetector.OVERHEAD_TIME,
         )
         assert all(task.result for task in tasks_batch)
 


### PR DESCRIPTION
- CUDA runtime does not support the fork start method, so other MP start methods are required
[see comment here](https://github.com/microsoft/onnxruntime/issues/7846#issuecomment-850217402)

- Lambda function as the default for `handle_condition` cannot be pickled (required for both "spawn" and "forkserver" start methods)