### PR TITLE
Priority queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.10.15
+- Add Priority queues
+
 # 1.10.14
 - Route task to a specific worker queue according to handle_condition
 

--- a/aqueduct/metrics/task.py
+++ b/aqueduct/metrics/task.py
@@ -32,11 +32,19 @@ class TaskMetrics(TasksMetricsStorage):
         self._transfer_timer = TransferTimer(transfer_from)
         self._transfer_timer.start()
 
-    def stop_transfer_timer(self, transfer_to: str):
+    def stop_transfer_timer(self, transfer_to: str, priority: int = 0):
         self._transfer_timer.stop()
         from_ = self._transfer_timer.transfer_from
-        self.transfer_times.add(f'from_{from_}_to_{transfer_to}', self._transfer_timer.seconds)
+        name = (
+            f'p_{priority}_from_{from_}_to_{transfer_to}'
+            if priority > 0 else f'from_{from_}_to_{transfer_to}'
+        )
+        self.transfer_times.add(name, self._transfer_timer.seconds)
 
-    def save_task_size(self, task_size: int, transfer_to: str):
+    def save_task_size(self, task_size: int, transfer_to: str, priority: int = 0):
         from_ = self._transfer_timer.transfer_from
-        self.task_sizes.add(f'from_{from_}_to_{transfer_to}', task_size)
+        name = (
+            f'p_{priority}_from_{from_}_to_{transfer_to}'
+            if priority > 0 else f'from_{from_}_to_{transfer_to}'
+        )
+        self.task_sizes.add(name, task_size)

--- a/aqueduct/queues.py
+++ b/aqueduct/queues.py
@@ -13,8 +13,8 @@ class FlowStepQueue:
     handle_condition: HandleConditionType
 
 
-def select_next_queue(queues: List[FlowStepQueue], task: BaseTask, start_index: int = 0) -> mp.Queue:
-    for step_queue in queues[start_index:]:
+def select_next_queue(queues: List[List[FlowStepQueue]], task: BaseTask, start_index: int = 0) -> mp.Queue:
+    for step_queue in queues[task.priority][start_index:]:
         if step_queue.handle_condition(task):
             return step_queue.queue
-    return queues[-1].queue
+    return queues[task.priority][-1].queue

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -27,6 +27,7 @@ Flow constructor arguments
 - ``metrics_exporter`` - class that allows to export `metrics <metrics.rst>`_
 - ``queue_size`` - the size of queues between ``FlowSteps``. If ``queue_size`` is not specified, then aqueduct calculates the queue size for each step depending on the step's batch size, but minimal 20 tasks
 - ``mp_start_method`` - Start method for `process creation <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_ (``spawn``, ``fork``, ``forkserver``)
+- ``queue_priorities`` - number of priority queues. Default is 1. `More about priority queues <priority_queues.rst>`_
 
 Flow main methods
 =================

--- a/docs/priority_queues.rst
+++ b/docs/priority_queues.rst
@@ -1,0 +1,56 @@
+Priority queues
+===============
+
+Aqueduct supports tasks with priorities.
+To achieve this Aqueduct creates parallel queues and gets tasks from queues with higher priority first.
+
+To use this feature you need
+
+- Set how many priorities you are gonna need in ``Flow`` instance by setting up ``queue_priorities`` to ``2`` or higher
+- Set task priority using task method ``set_priority`` before sending it to ``process`` function
+- Task priority should be between ``0`` and ``queue_priorities - 1``. Higher value higher priority
+
+Example
+-------
+.. code-block:: python
+
+    class Task(BaseTask):
+        result: Optional[int]
+        def __init__(self):
+            super().__init__()
+            self.result = None
+
+    class ProcessorHandler(BaseTaskHandler):
+        def handle(self, *tasks: Task):
+            for task in tasks:
+                task.result = 42
+
+    def get_flow() -> Flow:
+        return Flow(
+            FlowStep(ProcessorHandler()),
+            metrics_enabled=False,
+            
+            # Set how many priorities you are gonna need
+            queue_priorities=2,
+        )
+
+    async def main():
+        flow = get_flow()
+        flow.start()
+
+        normal_task = Task()
+
+        important_task = Task()
+
+        # Task priority should be between 0 and queue_priorities - 1
+        important_task.set_priority(1)
+
+        normal_future = asyncio.create_task(flow.process(normal_task))
+        normal_future.add_done_callback(lambda _: print('normal task finished'))
+
+        important_future = asyncio.create_task(flow.process(important_task))
+        important_future.add_done_callback(lambda _: print('important task finished'))
+        await asyncio.gather(normal_future, important_future)
+
+    if __name__ == '__main__':
+        asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ packages = ['aqueduct']
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.10.14',
+    version='1.11.0',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -177,6 +177,14 @@ def slow_sleep_handlers() -> Tuple[SleepHandler, ...]:
         SetResultSleepHandler(0.2),
     )
 
+@pytest.fixture
+def slow_priority_queue_handlers() -> Tuple[SleepHandler, ...]:
+    return (
+        SleepHandler1(0.1),
+        SleepHandler2(0.1),
+        SetResultSleepHandler(0.1),
+    )
+
 
 @asynccontextmanager
 async def run_flow(flow: Flow):
@@ -194,6 +202,11 @@ async def simple_flow(loop, sleep_handlers: Tuple[SleepHandler, ...]) -> Flow:
 @pytest.fixture
 async def slow_simple_flow(loop, slow_sleep_handlers: Tuple[SleepHandler, ...]) -> Flow:
     async with run_flow(Flow(*slow_sleep_handlers)) as flow:
+        yield flow
+
+@pytest.fixture
+async def slow_priority_queue_flow(loop, slow_priority_queue_handlers: Tuple[SleepHandler, ...]) -> Flow:
+    async with run_flow(Flow(*slow_priority_queue_handlers, queue_priorities=2)) as flow:
         yield flow
 
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -51,8 +51,10 @@ def worker():
         iq = multiprocessing.Queue(10000)
         oq = multiprocessing.Queue(10000)
         queues = [
-            FlowStepQueue(iq, lambda _: True),
-            FlowStepQueue(oq, lambda _: True),
+            [
+                FlowStepQueue(iq, lambda _: True),
+                FlowStepQueue(oq, lambda _: True),
+            ]
         ]
         worker = Worker(
             queues=queues,
@@ -60,6 +62,7 @@ def worker():
             batch_size=batch_size,
             batch_timeout=batch_timeout,
             batch_lock=None,
+            read_lock=multiprocessing.RLock(),
             step_number=1)
         return worker, iq
 


### PR DESCRIPTION
- Add field `queue_priorities` to `Flow` to indicate how many priorities you are gonna need
- Add `priority` field to `Task` and `set_priority` method
- Add metrics
- Add test
- Add docs

Basic idea
- Create a separate parallel queues for each priority
- Send Task to queues using priority field from Task
- Worker fetches tasks from queues with higher priority first

To wait with timeout on multiple `mp.Queue` simultaneously, I get all `_reader`s from `mp.Queue` and use `mp.connection.wait` to wait with timeout. 


