### PR TITLE
WIP: Fix potential normal-queue starvation. Always get tasks from all queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.11.1
+- Fix potential normal-queue starvation
+
 # 1.11.0
 - Add Priority queues
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ packages = ['aqueduct']
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.11.0',
+    version='1.11.1.dev0',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',


### PR DESCRIPTION
We can have potential normal-queue starvation if we have the same amount of tasks in both priority and normal queue

This fix tries to address this issue.

WIP, no merge