### PR TITLE
Restore signals for successful termination of processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.11.2
+- restore signals for successful termination of processes during flow.stop() if they were overridden
+
 # 1.11.1
 - Update setup requirements: add extras - aiohttp, numpy
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras = {
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.11.1',
+    version='1.11.2',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',


### PR DESCRIPTION
Sometimes some web frameworks (e.g. unicorn) override signal handlers. If processes use start method fork,
so when we call flow.stop() processes do not terminate and hang. Here we restore the signals we need.
Signed-off-by: Niyaz Khabibulin <nnkhabibulin@avito.ru>