### PR TITLE
Python3.12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.11.7
+- Update `cffi` version to allow python3.12 support, add `setuptools` to requirements
+
 # 1.11.6
 - Add metrics with count if running and dead processes
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 numpy
 aiohttp
-cffi==1.15.0
+cffi==1.16.0
 psutil==5.9.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@ numpy
 aiohttp
 cffi==1.16.0
 psutil==5.9.4
+setuptools==70.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras = {
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.11.6',
+    version='1.11.7',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ packages = ['aqueduct']
 required = [
     'cffi==1.16.0',
     'psutil==5.9.4',
+    'setuptools==70.2.0',
 ]
 
 extras = {

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 packages = ['aqueduct']
 
 required = [
-    'cffi==1.15.0',
+    'cffi==1.16.0',
     'psutil==5.9.4',
 ]
 


### PR DESCRIPTION
- Updated cffi to 1.16.0 version to allow python3.12 support
- Added setuptools (cffi requirement https://cffi.readthedocs.io/en/stable/whatsnew.html#v1-16-0)

