### PR TITLE
fix: increase subprocess join timeout for pytest-cov support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.13.1
+- Fix subprocess join timeout to allow pytest-cov to collect coverage data from child processes
+
 # 1.13.0
 - Add socket transport to support concurrent web workers compatibility with 1 Flow instance
 

--- a/aqueduct/flow.py
+++ b/aqueduct/flow.py
@@ -449,15 +449,16 @@ class Flow:
             await asyncio.sleep(sleep_sec)
 
     @staticmethod
-    def _join_context(context: ProcessContext, timeout_sec: float = 0.01):
-        try:
-            context.join(timeout_sec)
-        except (ProcessExitedException, ProcessRaisedException):
-            pass
-
-        for p in context.processes:
-            if p.is_alive():
-                os.kill(p.pid, signal.SIGKILL)
+    def _join_context(context: ProcessContext, timeout_sec: float = 5.0):
+        # First, try to join processes gracefully using join_all().
+        # This gives subprocesses time to flush coverage data (needed for
+        # pytest-cov subprocess support) and perform other cleanup.
+        # See: https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+        if not context.join_all(timeout=timeout_sec):
+            # Some processes didn't exit in time — escalate to SIGKILL.
+            for p in context.processes:
+                if p.is_alive():
+                    os.kill(p.pid, signal.SIGKILL)
 
     @property
     def _processes_context(self) -> ProcessContext:

--- a/aqueduct/multiprocessing.py
+++ b/aqueduct/multiprocessing.py
@@ -158,6 +158,29 @@ class ProcessContext:
         msg += original_trace
         raise ProcessRaisedException(msg, error_index, failed_process.pid)
 
+    def join_all(self, timeout=None):
+        r"""
+        Joins all processes in this context, waiting up to ``timeout`` seconds
+        for each process to exit.
+
+        This method does not raise on non-zero exit codes — it simply waits
+        for processes to finish. Useful for coverage tools (e.g. pytest-cov)
+        that need subprocesses to be properly joined before the parent exits.
+
+        Returns ``True`` if all processes joined within the timeout,
+        ``False`` if any process is still alive.
+
+        Arguments:
+            timeout (float): Seconds to wait per process. ``None`` = block forever.
+        """
+        all_joined = True
+        for process in self.processes:
+            if process.is_alive():
+                process.join(timeout)
+                if process.is_alive():
+                    all_joined = False
+        return all_joined
+
 
 def start_processes(fn, args=(), nprocs=1, join=True, daemon=False,
                     start_method='spawn', on_start_wait: float = 0):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras = {
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.13.0',
+    version='1.13.1',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',


### PR DESCRIPTION
The previous _join_context() used a 10ms join timeout before escalating to SIGKILL. This was too short for subprocesses to exit cleanly and flush their coverage data, breaking pytest-cov subprocess coverage.

Changes:
- Add join_all() method to ProcessContext for graceful process joining
- Increase _join_context default timeout from 10ms to 5s
- Use join_all() before escalating to SIGKILL
- SIGKILL is only used when processes exceed the timeout

Fixes #20