### PR TITLE
Require `cffi` for runtime (regression since v1.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.14.0
+- Require `cffi` for runtime (regression since v1.12.0)
+- Relax `cffi`, `psutil` and `setuptools` version constraints
+
 # 1.13.1
 - Fix subprocess join timeout to allow pytest-cov to collect coverage data from child processes
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 numpy
 aiohttp
-cffi>=1.13.0,<2.0.0
-psutil==5.9.4
-setuptools>=42.0.0,<81.0.0
+cffi>=1.13.0,<=2.1.0
+psutil>=5.9.4,<8
+setuptools>=42.0.0,<=83.0.0

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,13 @@ with open('README.rst') as f:
 packages = ['aqueduct']
 
 required_setup = [
-    'cffi>=1.13.0,<2.0.0',
-    'setuptools>=42.0.0,<81.0.0',
+    'cffi>=1.13.0,<=2.1.0',
+    'setuptools>=42.0.0,<=83.0.0',
 ]
 
 required = [
-    'psutil==5.9.4',
+    'cffi>=1.13.0,<=2.1.0',
+    'psutil>=5.9.4,<8',
 ]
 
 extras = {
@@ -26,7 +27,7 @@ extras = {
 setup(
     name='aqueduct',
     packages=find_packages(),
-    version='1.13.1',
+    version='1.14.0',
     license='MIT',
     license_files='LICENSE.txt',
     author='Data Science SWAT',


### PR DESCRIPTION
Commit 82e435e5d58a043a32f123277e3fb515da1c4c88 wrongly assumes `cffi` is required for build only.

Fixes `ModuleNotFoundError: No module named '_cffi_backend'` error when `import aqueduct` runs without `cffi` installed.

Also, relax `cffi`, `psutil` and `setuptools` version requirements.